### PR TITLE
feat: add dependabot interval to weekly 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,4 +22,4 @@ updates:
       - your-ehsan
     target-branch: development
     schedule:
-      interval: 'daily'
+      interval: 'weekly'


### PR DESCRIPTION
Fixes #65 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted the dependency update schedule for npm packages, shifting the checks from daily to weekly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->